### PR TITLE
Setup GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,19 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# test
+# Test Repository
+
+This repository demonstrates how to automatically deploy a simple static site to a development environment using **GitHub Pages**.
+
+## Local development
+
+The static site lives in the `site` directory. You can open `site/index.html` directly in your browser or serve it with any static file server.
+
+## Continuous deployment
+
+A GitHub Actions workflow in `.github/workflows/deploy.yml` publishes the contents of the `site` directory to the `gh-pages` branch whenever code is pushed to the `main` branch. Once GitHub Pages is enabled in the repository settings to serve from the `gh-pages` branch, every push automatically deploys the latest site.
+
+After pushing changes to `main`, visit `https://<your-username>.github.io/<your-repo>` to see the dev environment.

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Dev Environment</title>
+</head>
+<body>
+  <h1>Hello from the dev environment!</h1>
+  <p>If you see this page, the GitHub Pages deployment succeeded.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple static site under `site/`
- deploy `site` via GitHub Actions using `peaceiris/actions-gh-pages`
- document how to enable and view the deployed dev environment

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68816a01e59883278a90dfeda401f0c7